### PR TITLE
feat-remove-hostname-if-blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,10 @@ alternate hostname.
 
 Note that these hostnames are only stored in the integration, and will not be passed back to the gateway or client device.
 
-`List Client Hostnames` can be used to show which clients have had an alternate hostname provided.
+`List Client Hostnames` can be used to show which clients have had an alternate hostname provided by `Set Client Hostname`.
 
-`Clear Client Hostname` can be used to remove one or all alternate hostnames.
+`Clear Client Hostname` can be used to remove one or all alternate hostnames. Using `Set Client Hostname` with a blank
+hostname will also clear the hostname for a device.
 
 `Get Gateway`, `Get Gateway Clients`, `Get Gateway SIM Card`, `Get Access Point`, and `Get Cell Status` return data that
 is identical to that provided by the aggregate sensor entities above, but without filling history.

--- a/custom_components/tmobile_home_internet/manifest.json
+++ b/custom_components/tmobile_home_internet/manifest.json
@@ -11,6 +11,6 @@
   "iot_class": "local_polling",
   "requirements": [ "pytmhi==1.1.1" ],
   "ssdp": [],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "zeroconf": []
 }

--- a/custom_components/tmobile_home_internet/sensor.py
+++ b/custom_components/tmobile_home_internet/sensor.py
@@ -301,15 +301,20 @@ class GatewayDeviceSensor(GatewaySensor):
         new_client = { 'mac' : mac_address, 'name' : hostname }
         found = False
 
-        # Update hostname if entry exists
-        for client in edited_clients:
-            if 'mac' in client and client['mac'].upper() == mac_address.upper():
-                client.update(new_client)
-                found = True
+        # Remove client if blank hostname
+        if len(hostname) == 0:
+            edited_clients = [d for d in edited_clients if d.get('mac').upper() != mac_address.upper()]
+        else:
 
-        # Otherwise, add new entry to list
-        if not found:
-            edited_clients.append(new_client)
+            # Update hostname if entry exists
+            for client in edited_clients:
+                if 'mac' in client and client['mac'].upper() == mac_address.upper():
+                    client.update(new_client)
+                    found = True
+
+            # Otherwise, add new entry to list
+            if not found:
+                edited_clients.append(new_client)
 
         await self._store.async_save(edited_clients)
 


### PR DESCRIPTION
`Set Client Hostname` with a blank `hostname` will now remove a local alternate hostname, same as `Clear Client Hostname`.