### PR TITLE
Feature: Support G5AR Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ cards:
             name: 2.4GHz
           - entity: switch.t_mobile_edit_ssid_5_0ghz
             name: 5.0GHz
+# NOTE! Uncomment for G5AR. Comments will not be preserved in YAML.
+#          - entity: switch.t_mobile_edit_ssid_6_0ghz
+#            name: 6.0GHz
         show_header_toggle: false
         title: Edit SSID
       - type: horizontal-stack

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Several types of entities are provided:
 
 
 ### Simple Sensor Entities
-`Simple Sensor Entities` can be used directly on dashboards in cards such as the `Entities` card.
+`Simple Sensor Entities` can be used directly on dashboards in cards such as the `Entities` card. All
+`4G` and `5G` signal-related entities are disabled by default, since they update very frequently and
+are not supported by all gateway models.
 
 All entities begin with `T-Mobile`, which will be omitted from the "Friendly Name" here for brevity.
 

--- a/custom_components/tmobile_home_internet/const.py
+++ b/custom_components/tmobile_home_internet/const.py
@@ -27,6 +27,10 @@ SCHEMA_SERVICE_ENABLE_50_WIFI: Final = {
     vol.Required("enabled"): cv.boolean,
 }
 
+SCHEMA_SERVICE_ENABLE_60_WIFI: Final = {
+    vol.Required("enabled"): cv.boolean,
+}
+
 SCHEMA_SERVICE_SET_24_WIFI_POWER: Final = {
     vol.Required("power_level"): vol.In(["Full","Half"]),
 }
@@ -61,6 +65,7 @@ SCHEMA_SERVICE_GET_CELL_STATUS: Final = {}
 SERVICE_REBOOT_GATEWAY: Final = "reboot_gateway"
 SERVICE_ENABLE_24_WIFI: Final = "wifi24ghz_enable"
 SERVICE_ENABLE_50_WIFI: Final = "wifi50ghz_enable"
+SERVICE_ENABLE_60_WIFI: Final = "wifi60ghz_enable"
 SERVICE_SET_24_WIFI_POWER: Final = "set_wifi24ghz_power"
 SERVICE_SET_50_WIFI_POWER: Final = "set_wifi50ghz_power"
 SERVICE_GET_CLIENT_LIST: Final = "get_client_list"

--- a/custom_components/tmobile_home_internet/select.py
+++ b/custom_components/tmobile_home_internet/select.py
@@ -82,6 +82,11 @@ class GatewayWiFi24GHzChannelSelect(GatewaySelect):
         return slugify(f"{self._entity_type}_tmobile_home_internet_wifi_2_4GHz_channel")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def options(self) -> list[str]:
         """A list of available options as strings"""
         return ["Auto", "1", "2", "3"]
@@ -90,7 +95,10 @@ class GatewayWiFi24GHzChannelSelect(GatewaySelect):
     def current_option(self) -> str:
         """The current select option"""
         access_point = self._coordinator.data["access_point"]
-        return access_point["2.4ghz"]["channel"]
+        if "2.4ghz" in access_point:
+          if "channel" in access_point["2.4ghz"]:
+            return access_point["2.4ghz"]["channel"]
+        return None
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -123,6 +131,11 @@ class GatewayWiFi50GHzChannelSelect(GatewaySelect):
         return slugify(f"{self._entity_type}_tmobile_home_internet_wifi_5_0GHz_channel")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def options(self) -> list[str]:
         """A list of available options as strings"""
         return ["Auto", "36", "40", "44", "48", "52", "56", "60", "64", "100", "104", "108", "112", "116", "120", "124", "128", "132", "136", "140", "144", "149", "153", "157", "161", "165"]
@@ -131,7 +144,10 @@ class GatewayWiFi50GHzChannelSelect(GatewaySelect):
     def current_option(self) -> str:
         """The current select option"""
         access_point = self._coordinator.data["access_point"]
-        return access_point["5.0ghz"]["channel"]
+        if "5.0ghz" in access_point:
+          if "channel" in access_point["5.0ghz"]:
+            return access_point["5.0ghz"]["channel"]
+        return None
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -164,6 +180,11 @@ class GatewayWiFi24GHzBandwidthSelect(GatewaySelect):
         return slugify(f"{self._entity_type}_tmobile_home_internet_wifi_2_4GHz_bandwidth")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def options(self) -> list[str]:
         """A list of available options as strings"""
         return ["Auto", "20MHz", "40MHz"]
@@ -172,7 +193,10 @@ class GatewayWiFi24GHzBandwidthSelect(GatewaySelect):
     def current_option(self) -> str:
         """The current select option"""
         access_point = self._coordinator.data["access_point"]
-        return access_point["2.4ghz"]["channelBandwidth"]
+        if "2.4ghz" in access_point:
+          if "channelBandwidth" in access_point["2.4ghz"]:
+            return access_point["2.4ghz"]["channelBandwidth"]
+        return None
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -205,6 +229,11 @@ class GatewayWiFi50GHzBandwidthSelect(GatewaySelect):
         return slugify(f"{self._entity_type}_tmobile_home_internet_wifi_5_0GHz_bandwidth")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def options(self) -> list[str]:
         """A list of available options as strings"""
         return ["Auto", "20MHz", "40MHz", "80MHz"]
@@ -213,7 +242,10 @@ class GatewayWiFi50GHzBandwidthSelect(GatewaySelect):
     def current_option(self) -> str:
         """The current select option"""
         access_point = self._coordinator.data["access_point"]
-        return access_point["5.0ghz"]["channelBandwidth"]
+        if "5.0ghz" in access_point:
+          if "channelBandwidth" in access_point["5.0ghz"]:
+            return access_point["5.0ghz"]["channelBandwidth"]
+        return None
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/custom_components/tmobile_home_internet/sensor.py
+++ b/custom_components/tmobile_home_internet/sensor.py
@@ -636,6 +636,11 @@ class Gateway4gBandsSensor(GatewaySensor):
         return slugify(f"{self._entity_type}_tmobile_home_internet_4g_bands")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def native_value(self) -> str | None:
         """Return the value of this sensor."""
         if "4g" not in self.coordinator.data["cell"]:
@@ -664,6 +669,11 @@ class Gateway4gRSRPSensor(GatewaySensor):
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
         return slugify(f"{self._entity_type}_tmobile_home_internet_4g_RSRP")
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
 
     @property
     def device_class(self) -> SensorDeviceClass | None:
@@ -710,6 +720,11 @@ class Gateway4gRSRQSensor(GatewaySensor):
         return slugify(f"{self._entity_type}_tmobile_home_internet_4g_RSRQ")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return the type of sensor."""
         return SensorDeviceClass.SIGNAL_STRENGTH
@@ -752,6 +767,11 @@ class Gateway4gSINRSensor(GatewaySensor):
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
         return slugify(f"{self._entity_type}_tmobile_home_internet_4g_SINR")
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
 
     @property
     def device_class(self) -> SensorDeviceClass | None:
@@ -798,6 +818,11 @@ class Gateway4gAntennaSensor(GatewaySensor):
         return slugify(f"{self._entity_type}_tmobile_home_internet_4g_antenna")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def native_value(self) -> str | None:
         """Return the value of this sensor."""
         if "4g" not in self.coordinator.data["cell"]:
@@ -828,11 +853,18 @@ class Gateway4gBandwidthSensor(GatewaySensor):
         return slugify(f"{self._entity_type}_tmobile_home_internet_4g_bandwidth")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def native_value(self) -> str | None:
         """Return the value of this sensor."""
-        if "4g" not in self.coordinator.data["cell"]:
-            return None
-        return self.coordinator.data["cell"]["4g"]["bandwidth"]
+        cell = self._coordinator.data["cell"]
+        if "4g" in cell:
+          if "bandwidth" in cell["4g"]:
+            return cell["4g"]["bandwidth"]
+        return None
 
 
 class Gateway4gECGISensor(GatewaySensor):
@@ -858,11 +890,18 @@ class Gateway4gECGISensor(GatewaySensor):
         return slugify(f"{self._entity_type}_tmobile_home_internet_4g_ecgi")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def native_value(self) -> int | None:
         """Return the value of this sensor."""
-        if "4g" not in self.coordinator.data["cell"]:
-            return None
-        return self.coordinator.data["cell"]["4g"]["ecgi"]
+        cell = self._coordinator.data["cell"]
+        if "4g" in cell:
+          if "ecgi" in cell["4g"]:
+            return cell["4g"]["ecgi"]
+        return None
 
 
 class Gateway5gBandsSensor(GatewaySensor):
@@ -1081,11 +1120,18 @@ class Gateway5gBandwidthSensor(GatewaySensor):
         return slugify(f"{self._entity_type}_tmobile_home_internet_5g_bandwidth")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def native_value(self) -> str | None:
         """Return the value of this sensor."""
-        if "5g" not in self.coordinator.data["cell"]:
-            return None
-        return self.coordinator.data["cell"]["5g"]["bandwidth"]
+        cell = self._coordinator.data["cell"]
+        if "5g" in cell:
+          if "bandwidth" in cell["5g"]:
+            return cell["5g"]["bandwidth"]
+        return None
 
 
 class Gateway5gECGISensor(GatewaySensor):

--- a/custom_components/tmobile_home_internet/sensor.py
+++ b/custom_components/tmobile_home_internet/sensor.py
@@ -16,6 +16,7 @@ from .const import (
     SERVICE_REBOOT_GATEWAY,
     SERVICE_ENABLE_24_WIFI,
     SERVICE_ENABLE_50_WIFI,
+    SERVICE_ENABLE_60_WIFI,
     SERVICE_SET_24_WIFI_POWER,
     SERVICE_SET_50_WIFI_POWER,
     SERVICE_SET_CLIENT_HOSTNAME,
@@ -30,6 +31,7 @@ from .const import (
     SCHEMA_SERVICE_REBOOT_GATEWAY,
     SCHEMA_SERVICE_ENABLE_24_WIFI,
     SCHEMA_SERVICE_ENABLE_50_WIFI,
+    SCHEMA_SERVICE_ENABLE_60_WIFI,
     SCHEMA_SERVICE_SET_24_WIFI_POWER,
     SCHEMA_SERVICE_SET_50_WIFI_POWER,
     SCHEMA_SERVICE_SET_CLIENT_HOSTNAME,
@@ -82,6 +84,14 @@ async def async_setup_entry(
         SERVICE_ENABLE_50_WIFI,
         SCHEMA_SERVICE_ENABLE_50_WIFI,
         "_enable_50_wifi",
+        [GatewayDeviceEntityFeature.CAN_CALL_SERVICES],
+    )
+
+    # This will call Entity._enable_60_wifi
+    platform.async_register_entity_service(
+        SERVICE_ENABLE_60_WIFI,
+        SCHEMA_SERVICE_ENABLE_60_WIFI,
+        "_enable_60_wifi",
         [GatewayDeviceEntityFeature.CAN_CALL_SERVICES],
     )
 

--- a/custom_components/tmobile_home_internet/sensor.py
+++ b/custom_components/tmobile_home_internet/sensor.py
@@ -927,6 +927,11 @@ class Gateway5gBandsSensor(GatewaySensor):
         return slugify(f"{self._entity_type}_tmobile_home_internet_5g_bands")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def native_value(self) -> str | None:
         """Return the value of this sensor."""
         if "5g" not in self.coordinator.data["cell"]:
@@ -955,6 +960,11 @@ class Gateway5gRSRPSensor(GatewaySensor):
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
         return slugify(f"{self._entity_type}_tmobile_home_internet_5g_RSRP")
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
 
     @property
     def device_class(self) -> SensorDeviceClass | None:
@@ -1002,6 +1012,11 @@ class Gateway5gRSRQSensor(GatewaySensor):
         return slugify(f"{self._entity_type}_tmobile_home_internet_5g_RSRQ")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return the type of sensor."""
         return SensorDeviceClass.SIGNAL_STRENGTH
@@ -1046,6 +1061,11 @@ class Gateway5gSINRSensor(GatewaySensor):
         return slugify(f"{self._entity_type}_tmobile_home_internet_5g_SINR")
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
+
+    @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return the type of sensor."""
         return SensorDeviceClass.SIGNAL_STRENGTH
@@ -1088,6 +1108,11 @@ class Gateway5gAntennaSensor(GatewaySensor):
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
         return slugify(f"{self._entity_type}_tmobile_home_internet_5g_antenna")
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
 
     @property
     def native_value(self) -> str | None:
@@ -1155,6 +1180,11 @@ class Gateway5gECGISensor(GatewaySensor):
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
         return slugify(f"{self._entity_type}_tmobile_home_internet_5g_ecgi")
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Set entity disabled by default."""
+        return False
 
     @property
     def native_value(self) -> int | None:

--- a/custom_components/tmobile_home_internet/services.yaml
+++ b/custom_components/tmobile_home_internet/services.yaml
@@ -146,16 +146,3 @@ get_cell_status:
       integration: tmobile_home_internet
       device_class: gateway
 
-
-# set_wifi_ssid:
-#   target:
-#     entity:
-#       integration: tmobile_home_internet
-#       device_class: gateway
-#   fields:
-#     ssid:
-#       required: true
-#       example: "MyWifi"
-#       selector:
-#         text:
-#           type: "text"

--- a/custom_components/tmobile_home_internet/services.yaml
+++ b/custom_components/tmobile_home_internet/services.yaml
@@ -30,6 +30,19 @@ wifi50ghz_enable:
       selector:
         boolean:
 
+wifi60ghz_enable:
+  target:
+    entity:
+      integration: tmobile_home_internet
+      device_class: gateway
+  fields:
+    enabled:
+      required: true
+      default: True
+      example: False
+      selector:
+        boolean:
+
 set_wifi24ghz_power:
   target:
     entity:

--- a/custom_components/tmobile_home_internet/strings.json
+++ b/custom_components/tmobile_home_internet/strings.json
@@ -45,6 +45,16 @@
         }
       }
     },
+    "wifi60ghz_enable": {
+      "name": "Enable/disable 6.0GHz Wi-Fi",
+      "description": "Enable/disable 6.0GHz Wi-Fi on T-Mobile Home Internet Gateways that support it.",
+      "fields": {
+        "enabled": {
+          "name": "Enabled",
+          "description": "Turns on or off the 6.0GHz WiFi. WARNING: Only turn WiFi off if you have a wired connection to your gateway. Gateway will reset if this setting is changed, and may lose communications for a minute or more."
+        }
+      }
+    },
     "set_wifi24ghz_power": {
       "name": "Set 2.4GHz Wi-Fi Transmission Power",
       "description": "Set 2.4GHz Wi-Fi transmission power level on T-Mobile Home Internet Gateway.",

--- a/custom_components/tmobile_home_internet/switch.py
+++ b/custom_components/tmobile_home_internet/switch.py
@@ -35,6 +35,7 @@ def _create_entities(hass: HomeAssistant, entry: dict):
 
     entities.append(GatewayWiFi24GHzSwitch(hass, entry, slow_coordinator, controller))
     entities.append(GatewayWiFi50GHzSwitch(hass, entry, slow_coordinator, controller))
+    entities.append(GatewayWiFi60GHzSwitch(hass, entry, slow_coordinator, controller))
     entities.append(GatewayEditSSIDsEditsPendingSwitch(hass, entry, slow_coordinator, controller))
     entities.append(GatewayEditSSIDsEditsNameValidSwitch(hass, entry, slow_coordinator, controller))
     entities.append(GatewayEditSSIDsEditsPasswordValidSwitch(hass, entry, slow_coordinator, controller))

--- a/custom_components/tmobile_home_internet/translations/en.json
+++ b/custom_components/tmobile_home_internet/translations/en.json
@@ -45,6 +45,16 @@
         }
       }
     },
+    "wifi60ghz_enable": {
+      "name": "Enable/disable 6.0GHz Wi-Fi",
+      "description": "Enable/disable 6.0GHz Wi-Fi on T-Mobile Home Internet Gateways that support it.",
+      "fields": {
+        "enabled": {
+          "name": "Enabled",
+          "description": "Turns on or off the 6.0GHz WiFi. WARNING: Only turn WiFi off if you have a wired connection to your gateway. Gateway will reset if this setting is changed, and may lose communications for a minute or more."
+        }
+      }
+    },
     "set_wifi24ghz_power": {
       "name": "Set 2.4GHz Wi-Fi Transmission Power",
       "description": "Set 2.4GHz Wi-Fi transmission power level on T-Mobile Home Internet Gateway.",

--- a/custom_components/tmobile_home_internet/utils.py
+++ b/custom_components/tmobile_home_internet/utils.py
@@ -34,6 +34,7 @@ async def set_ssid_edit_controls(hass: HomeAssistant, coordinator, ssid_index: i
     guest = coordinator.data["access_point"]['ssids'][ssid_index]["guest"]
     ssid2_4ghz = coordinator.data["access_point"]['ssids'][ssid_index]["2.4ghzSsid"]
     ssid5_0ghz = coordinator.data["access_point"]['ssids'][ssid_index]["5.0ghzSsid"]
+    ssid6_0ghz = coordinator.data["access_point"]['ssids'][ssid_index].get("6.0ghzSsid", False)  # May not exist on all gateways
 
     # Check ssidName
     name_valid = hass.states.get("switch.t_mobile_edit_ssid_edits_name_valid").state
@@ -127,6 +128,14 @@ async def set_ssid_edit_controls(hass: HomeAssistant, coordinator, ssid_index: i
     await hass.services.async_call(
                 "switch", action, 
                 {"entity_id": "switch.t_mobile_edit_ssid_5_0ghz"}, 
+                blocking=True
+            )
+
+    # Set 6.0ghzSsid to gateway value
+    action = "turn_on" if ssid6_0ghz else "turn_off"
+    await hass.services.async_call(
+                "switch", action,
+                {"entity_id": "switch.t_mobile_edit_ssid_6_0ghz"},
                 blocking=True
             )
 


### PR DESCRIPTION
T-Mobile's G5AR Gateway supports 5G Standalone (SA) mode, and as a result, 4G signal parameters are not always available.

In this version, all 4G and 5G signal entities are disabled by default, for performance as well as for the above reason. Users can enable them as needed.

Also, controlling 6G Wi-Fi is now supported if the gateway supports it.

Other adjustments were made for features not supported by the G5AR.

This closes #12.